### PR TITLE
Change energy supplier param to list

### DIFF
--- a/source/settlement-report/SettlementReports.Infrastructure/Helpers/DatabricksJobsHelper.cs
+++ b/source/settlement-report/SettlementReports.Infrastructure/Helpers/DatabricksJobsHelper.cs
@@ -88,7 +88,7 @@ public class DatabricksJobsHelper : IDatabricksJobsHelper
         };
         if (request.Filter.EnergySupplier != null)
         {
-            jobParameters.Add($"--energy-supplier-id={request.Filter.EnergySupplier}");
+            jobParameters.Add($"--energy-supplier-ids=[{request.Filter.EnergySupplier}]");
         }
 
         if (request.SplitReportPerGridArea)


### PR DESCRIPTION
The settlement report job is being prepared to accept multiple suppliers, this is to update our current one supplier to be send as a list instead.