### PR TITLE
ci: there's no longer anything called 'databricks'

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -63,7 +63,7 @@ jobs:
   dispatch_deploment_event:
     if: ${{ always() && !cancelled() && !failure() && (needs.changes.outputs.dotnet == 'true' || needs.changes.outputs.db_migrations == 'true') }}
     runs-on: ubuntu-latest
-    needs: [changes, dotnet_promote_prerelease, databricks_promote_prerelease]
+    needs: [changes, dotnet_promote_prerelease]
     steps:
       - name: Find associated pull request
         uses: Energinet-DataHub/.github/.github/actions/find-related-pr-number@v14
@@ -83,7 +83,7 @@ jobs:
           repository: ${{ vars.environment_repository_path }}
           event-type: settlement-report-deployment-request-domain
           # yamllint disable-line rule:quoted-strings
-          client-payload: '{"pr_number": "${{ steps.find_pull_request.outputs.pull_request_number }}", "dotnet": "${{ needs.changes.outputs.dotnet }}", "db_migrations": "${{ needs.changes.outputs.db_migrations }}", "databricks": "${{ needs.changes.outputs.databricks }}"}'
+          client-payload: '{"pr_number": "${{ steps.find_pull_request.outputs.pull_request_number }}", "dotnet": "${{ needs.changes.outputs.dotnet }}", "db_migrations": "${{ needs.changes.outputs.db_migrations }}"}'
 
   #
   # Send notification to teams channel if deployment dispatch failed


### PR DESCRIPTION
# Description

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [ ] Subsystem tests have been tested (by manually deploying to `dev_002`)
