### PR TITLE
Chore: Fixed problem where settlement report devcontainer cannot open on windows

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,11 +31,7 @@ ENV USER=vscode \
 # Add tool-versions and startup script
 COPY --chown=${USER}:${USER} .tool-versions $HOME/.tool-versions
 COPY --chown=${USER}:${USER} .devcontainer/scripts $HOME/scripts
-
-# Fixing line endings on windows
-RUN sed -i 's/\r$//' $HOME/scripts/install-asdf.sh \
-  && sed -i 's/\r$//' $HOME/scripts/post-create.sh \
-  && chmod +x $HOME/scripts/*
+RUN chmod +x $HOME/scripts/*
 
 
 # Install asdf

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,7 +27,6 @@ ENV USER=vscode \
     RUFF_CACHE_DIR=/home/vscode/.cache/ruff \
     PYTHONPYCACHEPREFIX=/home/vscode/.cache/pycache
 
-
 # Add tool-versions and startup script
 COPY --chown=${USER}:${USER} .tool-versions $HOME/.tool-versions
 COPY --chown=${USER}:${USER} .devcontainer/scripts $HOME/scripts

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,10 +31,15 @@ ENV USER=vscode \
 # Add tool-versions and startup script
 COPY --chown=${USER}:${USER} .tool-versions $HOME/.tool-versions
 COPY --chown=${USER}:${USER} .devcontainer/scripts $HOME/scripts
-RUN chmod +x $HOME/scripts/*
+
+# Fixing line endings on windows
+RUN sed -i 's/\r$//' $HOME/scripts/install-asdf.sh \
+  && sed -i 's/\r$//' $HOME/scripts/post-create.sh \
+  && chmod +x $HOME/scripts/*
+
 
 # Install asdf
-RUN $HOME/scripts/install-asdf.sh $ASDF_VERSION \
+RUN ./$HOME/scripts/install-asdf.sh $ASDF_VERSION \
   && echo 'export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"' >> $HOME/.bashrc \
   && echo 'export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"' >> $HOME/.zshrc
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,7 +32,6 @@ COPY --chown=${USER}:${USER} .tool-versions $HOME/.tool-versions
 COPY --chown=${USER}:${USER} .devcontainer/scripts $HOME/scripts
 RUN chmod +x $HOME/scripts/*
 
-
 # Install asdf
 RUN $HOME/scripts/install-asdf.sh $ASDF_VERSION \
   && echo 'export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"' >> $HOME/.bashrc \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -39,7 +39,7 @@ RUN sed -i 's/\r$//' $HOME/scripts/install-asdf.sh \
 
 
 # Install asdf
-RUN ./$HOME/scripts/install-asdf.sh $ASDF_VERSION \
+RUN $HOME/scripts/install-asdf.sh $ASDF_VERSION \
   && echo 'export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"' >> $HOME/.bashrc \
   && echo 'export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"' >> $HOME/.zshrc
 

--- a/.devcontainer/geh_settlement_report/devcontainer.json
+++ b/.devcontainer/geh_settlement_report/devcontainer.json
@@ -15,7 +15,11 @@
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
   "workspaceFolder": "/workspace/source/geh_settlement_report",
   "remoteUser": "vscode",
-  "postCreateCommand": "~/scripts/post-create.sh ~",
+  "postCreateCommand": {
+    "fixAsdfVolumePerms": "sudo chown -R $(whoami): /home/vscode/.asdf",
+    "fixCacheVolumePerms": "sudo chown -R $(whoami): /home/vscode/.cache",
+    "installDependencies": "~/scripts/post-create.sh ~"
+  },
   "postStartCommand": "uv sync",
   "mounts": [
     // We want to reuse asdf cache across containers

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,72 @@
+# Stolen from https://github.com/dotnet/runtime/blob/main/.gitattributes
+
+# Set default behavior to automatically normalize line endings.
+* text=auto
+
+*.doc  diff=astextplain
+*.DOC	diff=astextplain
+*.docx	diff=astextplain
+*.DOCX	diff=astextplain
+*.dot	diff=astextplain
+*.DOT	diff=astextplain
+*.pdf	diff=astextplain
+*.PDF	diff=astextplain
+*.rtf	diff=astextplain
+*.RTF	diff=astextplain
+
+*.jpg  	binary
+*.png 	binary
+*.gif 	binary
+
+*.lss 	text
+
+# Force bash scripts to always use lf line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work.
+*.in text eol=lf
+*.sh text eol=lf
+*.tool-versions text eol=lf
+
+# Likewise, force cmd and batch scripts to always use crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf
+
+*.cs text diff=csharp
+*.vb text
+*.resx text
+*.c text
+*.cpp text
+*.cxx text
+*.h text
+*.hxx text
+*.py text
+*.rb text
+*.java text
+*.html text
+*.htm text
+*.css text
+*.scss text
+*.sass text
+*.less text
+*.js text
+*.lisp text
+*.clj text
+*.sql text
+*.php text
+*.lua text
+*.m text
+*.asm text
+*.erl text
+*.fs text
+*.fsx text
+*.hs text
+
+*.csproj text
+*.vbproj text
+*.fsproj text
+*.dbproj text
+*.sln text eol=crlf
+
+# Set linguist language for .h files explicitly based on
+# https://github.com/github/linguist/issues/1626#issuecomment-401442069
+# this only affects the repo's language statistics
+*.h linguist-language=C

--- a/source/geh_settlement_report/uv.lock
+++ b/source/geh_settlement_report/uv.lock
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "geh-settlement-report"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "azure-core" },


### PR DESCRIPTION
# Description
To resolve the issue, I added the .gitattributes file to adjust the line endings. Additionally, the modifications to devcontainer.json were based on recommendations from JP.

To make the .gitattributes take action we have to re-add the files locally. This can be done by running:
git rm --cached -r .
git reset --hard

I will sent a message about this in the databricks teams channel, when the PR is merged.

<!-- INSERT DESCRIPTION HERE -->

## Pull-request quality

<!-- Please do not remove these, but leave them checked/unchecked as information for the reviewers -->
- [x] The title adheres to [this guide](https://github.com/Mech0z/GitHubGuidelines)
- [x] Tests are written and executed locally
- [x] Subsystem tests have been tested (by manually deploying to `dev_002`)
